### PR TITLE
simplify instructions to use provided github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Read more about the [Workflow Runs API](https://developer.github.com/v3/actions/
 
 ## Usage
 
-- Visit https://github.com/settings/tokens to generate a token with `public_repo` scope (or full `repo` scope for private repos).
-- Visit `https://github.com/:org/:repo/settings/secrets` to add a secret called `GH_ACCESS_TOKEN` with the token as the value.
 - Visit `https://api.github.com/repos/:org/:repo/actions/workflows` to find the Workflow ID you wish to auto-cancel.
 - Add a new file `.github/workflows/cancel.yml` with the following:
 
@@ -30,7 +28,7 @@ jobs:
       - uses: styfle/cancel-workflow-action@0.3.1
         with:
           workflow_id: 479426
-          access_token: ${{ secrets.GH_ACCESS_TOKEN }}
+          access_token: ${{ github.token }}
 ```
 
 _Note_: `workflow_id` accepts a comma separated list of IDs.


### PR DESCRIPTION
thanks for the action!

the automatic `${{ github.token }}` var that every action is provided is sufficient to be the `access_token` so you can remove a couple of the steps, making integrating this even easier.