### PR TITLE
Allow users to specify ignored branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ jobs:
       - uses: styfle/cancel-workflow-action@0.4.0
         with:
           workflow_id: 479426
+          ignored_branches: master,staging
           access_token: ${{ github.token }}
 ```
 
 _Note_: `workflow_id` accepts a comma separated list of IDs.
+_Note_: `ignored_branches` accepts a comma separated list of IDs. The script won't run on these branches.
 
 At the time of writing `0.4.0` is the latest release but you can select any [release](https://github.com/styfle/cancel-workflow-action/releases).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,21 @@ async function main() {
     headSha = payload.pull_request.head.sha;
   }
 
+  // Allow users to specify a branch to ignore
+  // This is useful, if you want to always run tests on master, but prevent parallel testing on PR's
+  let ignoredBranches = core.getInput('ignored_branches');
+  let ignoredBranchNames: string[] = [];
+  if (ignoredBranches) {
+    // The user may specify multiple branches, separated by commas
+    ignoredBranches.split(',')
+      .forEach(branchName => ignoredBranchNames.push(branchName));
+
+    if (ignoredBranchNames.includes(branch)) {
+      console.log(`Don't run on ignored branch ${branchName}`);
+      return;
+    }
+  }
+
   console.log({ eventName, sha, headSha, branch, owner, repo, GITHUB_RUN_ID });
   const token = core.getInput('access_token', { required: true });
   const workflow_id = core.getInput('workflow_id', { required: false });


### PR DESCRIPTION
Hi!

First of all, thanks for creating this action!

I'm having the current scenario, that I want to run tests for every pushed collection of commits for master and the staging environment. This is super useful, so in case something breaks on master, we can easily track down the broken commit.

Pull Requests on the other hands are getting pushed to and rebased all the time and it really doesn't matter if tests of an intermediate commit fail, as long as the last commit works properly.

Hence, I tried myself on adding a new option `ignored_branches`, which allows to specify a list of branches the script won't run on.

I'm not entirely sure on how to properly test this change, though.