### PR TITLE
MNT: Move vercel/ncc tp devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@actions/core": "1.2.6",
-    "@actions/github": "4.0.0",
-    "@vercel/ncc": "0.24.0"
+    "@actions/github": "4.0.0"
   },
   "devDependencies": {
+    "@vercel/ncc": "0.24.0",
     "typescript": "4.0.2"
   }
 }


### PR DESCRIPTION
Hello and thanks for this very useful Action!

I am wondering if vercel/ncc cannot be just in `devDependencies` as I don't see it used in the `.ts` file.