### PR TITLE
ENH: Support workflow_runs for pull_request from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
 ```
 
 
-### Advanced
+### Advanced: Canceling Other Workflows
 
 In some cases, you may wish to avoid modifying all your workflows and instead create a new workflow that cancels your other workflows. This can be useful when you have a problem with workflows getting queued.
 
@@ -54,6 +54,32 @@ jobs:
 
 - _Note_: `workflow_id` can be a Workflow ID (number) or Workflow File Name (string)
 - _Note_: `workflow_id` also accepts a comma separated list if you need to cancel multiple workflows
+
+### Advanced: Pull Requests from Forks
+
+The default GitHub token access is unable to cancel workflows for `pull_request`
+when a pull request is opened from a fork. Therefore, a special setup using
+`workflow_run`, which also works for `push`, is needed.
+Create a `.github/workflows/cancel.yml` with the following instead and replace
+"CI" with the workflow name that contains the `pull_request` workflow:
+
+```yml
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}
+```
+
+### Advanced: Ignore SHA
 
 In some cases, you may wish to cancel workflows when you close a Pull Request. Because this is not a push event, the SHA will be the same, so you must use the `ignore_sha` option.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.8.0
+    - uses: styfle/cancel-workflow-action@0.7.0
       with:
         workflow_id: ${{ github.event.workflow.id }}
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -5856,6 +5856,10 @@ async function main() {
         branch = payload.pull_request.head.ref;
         headSha = payload.pull_request.head.sha;
     }
+    else if (payload.workflow_run) {
+        branch = payload.workflow_run.head_branch;
+        headSha = payload.workflow_run.head_sha;
+    }
     console.log({ eventName, sha, headSha, branch, owner, repo, GITHUB_RUN_ID });
     const token = core.getInput('access_token', { required: true });
     const workflow_id = core.getInput('workflow_id', { required: false });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ async function main() {
   if (payload.pull_request) {
     branch = payload.pull_request.head.ref;
     headSha = payload.pull_request.head.sha;
+  } else if (payload.workflow_run) {
+    branch = payload.workflow_run.head_branch;
+    headSha = payload.workflow_run.head_sha;
   }
 
   console.log({ eventName, sha, headSha, branch, owner, repo, GITHUB_RUN_ID });
@@ -66,7 +69,7 @@ async function main() {
         new Date(run.created_at) < new Date(current_run.created_at)
       );
       console.log(`with ${runningWorkflows.length} runs to cancel.`);
-      
+
       for (const {id, head_sha, status, html_url} of runningWorkflows) {
         console.log('Canceling run: ', {id, head_sha, status, html_url});
         const res = await octokit.actions.cancelWorkflowRun({


### PR DESCRIPTION
I have a workflow that requires canceling previous runs for PRs opened from forks. The existing code does not work due to `GITHUB_TOKEN` limitations, but this should work.

You might want to take this PR for a spin before merge to make sure I did not break any existing functionality.

Might be related: #7, #8, #47, https://github.com/styfle/cancel-workflow-action/issues/54#issuecomment-767869282