### PR TITLE
Allow cancelling newer builds with `cancel_newer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ jobs:
           workflow_id: 479426
 ```
 
+### Advanced: Cancel newer builds
+
+Under certain circumstances it could be beneficial to cancel _newer_ workflows. For example, if there are no code
+changes, but you are pulling data from another source, there may be no need for subsequent builds that are currently
+queued. Using the `cancel_newer` option will cancel _ALL_ other builds for the same workflow.
+
+```yml
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  cleanup:
+    name: 'Clean up ALL other builds'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Cancel ALL build runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          ignore_sha: true
+          cancel_newer: true
+```
+
 ## Contributing
 
 - Clone this repo

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,15 @@ inputs:
   ignore_sha:
     description: 'Optional - Allow canceling other workflows with the same SHA. Useful for the `pull_request.closed` event.'
     required: false
-    default: false
+    default: 'false'
+  cancel_newer:
+    description: 'Cancel all queued and in progress workflows, even if they are newer'
+    required: false
+    default: 'false'
   access_token:
     description: 'Your GitHub Access Token, defaults to: {{ github.token }}'
     default: '${{ github.token }}'
+    required: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -5864,6 +5864,7 @@ async function main() {
     const token = core.getInput('access_token', { required: true });
     const workflow_id = core.getInput('workflow_id', { required: false });
     const ignore_sha = core.getInput('ignore_sha', { required: false }) === 'true';
+    const cancel_newer = core.getInput('cancel_newer', { required: false }) === 'true';
     console.log(`Found token: ${token ? 'yes' : 'no'}`);
     const workflow_ids = [];
     const octokit = github.getOctokit(token);
@@ -5894,7 +5895,7 @@ async function main() {
             console.log(branchWorkflows.map(run => `- ${run.html_url}`).join('\n'));
             const runningWorkflows = branchWorkflows.filter(run => (ignore_sha || run.head_sha !== headSha) &&
                 run.status !== 'completed' &&
-                new Date(run.created_at) < new Date(current_run.created_at));
+                (cancel_newer || new Date(run.created_at) < new Date(current_run.created_at)));
             console.log(`with ${runningWorkflows.length} runs to cancel.`);
             for (const { id, head_sha, status, html_url } of runningWorkflows) {
                 console.log('Canceling run: ', { id, head_sha, status, html_url });

--- a/dist/index.js
+++ b/dist/index.js
@@ -5895,6 +5895,7 @@ async function main() {
             console.log(branchWorkflows.map(run => `- ${run.html_url}`).join('\n'));
             const runningWorkflows = branchWorkflows.filter(run => (ignore_sha || run.head_sha !== headSha) &&
                 run.status !== 'completed' &&
+                run.id !== current_run.id &&
                 (cancel_newer || new Date(run.created_at) < new Date(current_run.created_at)));
             console.log(`with ${runningWorkflows.length} runs to cancel.`);
             for (const { id, head_sha, status, html_url } of runningWorkflows) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,15 +73,20 @@ async function main() {
       );
       console.log(`with ${runningWorkflows.length} runs to cancel.`);
 
+      const promises = [];
       for (const {id, head_sha, status, html_url} of runningWorkflows) {
         console.log('Canceling run: ', {id, head_sha, status, html_url});
-        const res = await octokit.actions.cancelWorkflowRun({
+        const current_promise = octokit.actions.cancelWorkflowRun({
           owner,
           repo,
           run_id: id
+        }).then((res) => {
+          console.log(`Cancel run ${id} responded with status ${res.status}`);
         });
-        console.log(`Cancel run ${id} responded with status ${res.status}`);
+        promises.push(current_promise);
       }
+      await Promise.all(promises);
+
     } catch (e) {
       const msg = e.message || e;
       console.log(`Error while canceling workflow_id ${workflow_id}: ${msg}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ async function main() {
   await Promise.all(workflow_ids.map(async (workflow_id) => {
     try {
       const { data } = await octokit.actions.listWorkflowRuns({
+        per_page: 100,
         owner,
         repo,
         // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ async function main() {
       const runningWorkflows = branchWorkflows.filter(run =>
         (ignore_sha || run.head_sha !== headSha) &&
         run.status !== 'completed' &&
+        run.id !== current_run.id && // Do not cancel yourself
         (cancel_newer || new Date(run.created_at) < new Date(current_run.created_at))
       );
       console.log(`with ${runningWorkflows.length} runs to cancel.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ async function main() {
   const token = core.getInput('access_token', { required: true });
   const workflow_id = core.getInput('workflow_id', { required: false });
   const ignore_sha = core.getInput('ignore_sha', { required: false }) === 'true';
+  const cancel_newer = core.getInput('cancel_newer', { required: false }) === 'true';
   console.log(`Found token: ${token ? 'yes' : 'no'}`);
   const workflow_ids: string[] = [];
   const octokit = github.getOctokit(token);
@@ -66,7 +67,7 @@ async function main() {
       const runningWorkflows = branchWorkflows.filter(run =>
         (ignore_sha || run.head_sha !== headSha) &&
         run.status !== 'completed' &&
-        new Date(run.created_at) < new Date(current_run.created_at)
+        (cancel_newer || new Date(run.created_at) < new Date(current_run.created_at))
       );
       console.log(`with ${runningWorkflows.length} runs to cancel.`);
 


### PR DESCRIPTION
Very happy to take feedback and suggestions on this PR, or for it to be ignored, this is a bit of a weird one. One thing I wondered about was the interplay between `cancel_newer` and `ignore_sha` as you may want to only cancel newer if the SHA is the same, so would love input on that.

## Changes:
1. Added a `cancel_newer` optional parameter, added documentation in `README.md`.
2. Added an ID check (as you can't rely on the Date difference with this option)
3. Increased the number of workflows downloaded to the max per page (100, up from the default of 30). If you want more than 100, you'd have to add Paging.
4. Sped up the cancelation process by sending all the cancelation requests at once, adding the Promises to an array, and awaiting the array at the end.
5. Changed `action.yml` to match the schema (I don't think it was causing any problems but just tidying up while I was there).

## Use Case:

We receive webhooks from a CMS when content is published and use this to build a new static website based on that content.

The CMS builds pages out of parts, and sends a publish event for every part of something thats being published. Irritatingly it does this even if the part hasn't changed, so every time we publish a page, we end up with 64 new workflows starting up. 

These tend to get queued, and we actually don't care which of the jobs finishes as the webhook only triggers the job, and the job will then go download the new content so all the jobs will get the same content.

The next problem we has is that we have multiple jobs starting at once, downloading a list of other jobs and trying to cancel them one at a time. GitHub doesn't wait for the job to be cancelled before returning a `202` response so its possible for two jobs to cancel each other. In order to reduce the chance of this happening we decided to send all of the cancellations in one go, and wait for the 202s in one lump at the end. **This change will improve the speed of the task for everyone with more than one workflow to cancel.**

It's not perfect, our builds are now so fast we still end up with > 1 job running to completion, but its not 64 running to completion and I think thats the best we can hope for. 