### PR TITLE
Mention permissions configuration in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ jobs:
       # ... etc
 ```
 
-
 ### Advanced: Canceling Other Workflows
 
 In some cases, you may wish to avoid modifying all your workflows and instead create a new workflow that cancels your other workflows. This can be useful when you have a problem with workflows getting queued.
@@ -120,6 +119,29 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 ```
+
+### Permissions control
+
+No change to permissions is required by default. The instructions below or for improved control over of those permissions.
+
+By default, Github creates the `GITHUB_TOKEN` for actions with some read/write permissions. It may be a good practice to switch to read-only permissions by default. Visit the [dedicated documentation page](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/disabling-or-limiting-github-actions-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository) for details.
+
+Permissions can be set in the workflow, globally or at job level, see the [reference manual page](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions). `cancel-workflow-action` only requires write access to the `actions` scope, so it is enough to have:
+
+```yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+```
+
+_Note_ : This is typical when global access is set to be restrictive. Only this job will elevate those permissions.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ jobs:
           access_token: ${{ github.token }}
 ```
 
-### Permissions control
+### Advanced: Token Permissions
 
-No change to permissions is required by default. The instructions below or for improved control over of those permissions.
+No change to permissions is required by default. The instructions below are for improved control over of those permissions.
 
-By default, Github creates the `GITHUB_TOKEN` for actions with some read/write permissions. It may be a good practice to switch to read-only permissions by default. Visit the [dedicated documentation page](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/disabling-or-limiting-github-actions-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository) for details.
+By default, GitHub creates the `GITHUB_TOKEN` for Actions with some read/write permissions. It may be a good practice to switch to read-only permissions by default. Visit the [dedicated documentation page](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/disabling-or-limiting-github-actions-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository) for details.
 
-Permissions can be set in the workflow, globally or at job level, see the [reference manual page](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions). `cancel-workflow-action` only requires write access to the `actions` scope, so it is enough to have:
+Permissions can be set for all Jobs in a Workflow or a specific Job, see the [reference manual page](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions). `cancel-workflow-action` only requires write access to the `actions` scope, so it is enough to have:
 
 ```yml
 jobs:


### PR DESCRIPTION
This documents how permissions can be restricted to the strict necessary for the `cancel-workflow-action`.

Since this is not mandatory for the action to work with the default GitHub settings, I placed it at the end of the readme.
I also mention that setting permission to the restrictive settings by default is a good practice. While this is not related to the action, I think this makes sense to explain why this paragraph was added.

Closes #83 