### PR TITLE
Add ignore_branches_on_push option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ jobs:
           all_but_latest: true
 ```
 
+### Advanced: Ignore branches on push
+
+Sometimes you may only want to cancel workflow runs that are triggered by pull requests, but not by the default branch so that every commit to the default branch can be verified by full CI and receive a green checkmark.
+The branches listed in `ignore_branches_on_push` will be ignored by this action on push.
+
+```yml
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action
+        with:
+          ignore_branches_on_push: |
+            main
+            master
+```
+
 ### Advanced: Token Permissions
 
 No change to permissions is required by default. The instructions below are for improved control over of those permissions.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: "Cancel all actions but the last one"
     required: false
     default: 'false'
+  ignore_branches_on_push:
+    description: "Do not trigger cancellation for given branches when trigger event is push"
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9714,8 +9714,7 @@ async function main() {
     const workflow_run_event = payload && payload.workflow_run && payload.workflow_run.event;
     const is_push = workflow_run_event === 'push';
     console.log(`event: ${workflow_run_event}, is_push: ${is_push}`);
-    const should_ignore_on_push = ignore_branches_on_push && ignore_branches_on_push.indexOf(branch) >= 0;
-    console.log(`should_ignore_on_push: ${should_ignore_on_push}`);
+    const should_ignore_on_push = is_push && ignore_branches_on_push && ignore_branches_on_push.indexOf(branch) >= 0;
     if (should_ignore_on_push) {
         console.log(`Ignore cancellation on push for branch: ${branch}`);
         return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -140,7 +140,6 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const uuid_1 = __nccwpck_require__(5840);
 const oidc_utils_1 = __nccwpck_require__(8041);
 /**
  * The code to exit an action
@@ -170,20 +169,9 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
-        if (name.includes(delimiter)) {
-            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-        }
-        if (convertedVal.includes(delimiter)) {
-            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
-        }
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
+        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
     }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
+    command_1.issueCommand('set-env', { name }, convertedVal);
 }
 exports.exportVariable = exportVariable;
 /**
@@ -201,7 +189,7 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
+        file_command_1.issueFileCommand('PATH', inputPath);
     }
     else {
         command_1.issueCommand('add-path', {}, inputPath);
@@ -241,7 +229,10 @@ function getMultilineInput(name, options) {
     const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-    return inputs;
+    if (options && options.trimWhitespace === false) {
+        return inputs;
+    }
+    return inputs.map(input => input.trim());
 }
 exports.getMultilineInput = getMultilineInput;
 /**
@@ -274,8 +265,12 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
+    const filePath = process.env['GITHUB_OUTPUT'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
+    }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
 }
 exports.setOutput = setOutput;
 /**
@@ -404,7 +399,11 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
+    const filePath = process.env['GITHUB_STATE'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
+    }
+    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
 }
 exports.saveState = saveState;
 /**
@@ -470,13 +469,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.issueCommand = void 0;
+exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
+const uuid_1 = __nccwpck_require__(5840);
 const utils_1 = __nccwpck_require__(5278);
-function issueCommand(command, message) {
+function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -488,7 +488,22 @@ function issueCommand(command, message) {
         encoding: 'utf8'
     });
 }
-exports.issueCommand = issueCommand;
+exports.issueFileCommand = issueFileCommand;
+function prepareKeyValueMessage(key, value) {
+    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+    const convertedValue = utils_1.toCommandValue(value);
+    // These should realistically never happen, but just in case someone finds a
+    // way to exploit uuid generation let's not allow keys or values that contain
+    // the delimiter.
+    if (key.includes(delimiter)) {
+        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+    }
+    if (convertedValue.includes(delimiter)) {
+        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+    }
+    return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+}
+exports.prepareKeyValueMessage = prepareKeyValueMessage;
 //# sourceMappingURL=file-command.js.map
 
 /***/ }),
@@ -1159,7 +1174,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
+exports.getOctokitOptions = exports.GitHub = exports.defaults = exports.context = void 0;
 const Context = __importStar(__nccwpck_require__(4087));
 const Utils = __importStar(__nccwpck_require__(7914));
 // octokit + plugins
@@ -1168,13 +1183,13 @@ const plugin_rest_endpoint_methods_1 = __nccwpck_require__(3044);
 const plugin_paginate_rest_1 = __nccwpck_require__(4193);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
-const defaults = {
+exports.defaults = {
     baseUrl,
     request: {
         agent: Utils.getProxyAgent(baseUrl)
     }
 };
-exports.GitHub = core_1.Octokit.plugin(plugin_rest_endpoint_methods_1.restEndpointMethods, plugin_paginate_rest_1.paginateRest).defaults(defaults);
+exports.GitHub = core_1.Octokit.plugin(plugin_rest_endpoint_methods_1.restEndpointMethods, plugin_paginate_rest_1.paginateRest).defaults(exports.defaults);
 /**
  * Convience function to correctly format Octokit Options to pass into the constructor.
  *
@@ -9691,7 +9706,20 @@ async function main() {
     const workflow_id = core.getInput('workflow_id', { required: false });
     const ignore_sha = core.getBooleanInput('ignore_sha', { required: false });
     const all_but_latest = core.getBooleanInput('all_but_latest', { required: false });
+    const ignore_branches_on_push = core.getMultilineInput('ignore_branches_on_push', {
+        required: false,
+    });
+    console.log(`ignore_branches_on_push: ${JSON.stringify(ignore_branches_on_push)}`);
     console.log(`Found token: ${token ? 'yes' : 'no'}`);
+    const workflow_run_event = payload && payload.workflow_run && payload.workflow_run.event;
+    const is_push = workflow_run_event === 'push';
+    console.log(`event: ${workflow_run_event}, is_push: ${is_push}`);
+    const should_ignore_on_push = ignore_branches_on_push && ignore_branches_on_push.indexOf(branch) >= 0;
+    console.log(`should_ignore_on_push: ${should_ignore_on_push}`);
+    if (should_ignore_on_push) {
+        console.log(`Ignore cancellation on push for branch: ${branch}`);
+        return;
+    }
     const workflow_ids = [];
     const octokit = github.getOctokit(token);
     const { data: current_run } = await octokit.rest.actions.getWorkflowRun({

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,21 @@ async function main() {
   const workflow_id = core.getInput('workflow_id', { required: false });
   const ignore_sha = core.getBooleanInput('ignore_sha', { required: false });
   const all_but_latest = core.getBooleanInput('all_but_latest', { required: false });
+  const ignore_branches_on_push = core.getMultilineInput('ignore_branches_on_push', {
+    required: false,
+  });
+  console.log(`ignore_branches_on_push: ${JSON.stringify(ignore_branches_on_push)}`);
   console.log(`Found token: ${token ? 'yes' : 'no'}`);
+  const workflow_run_event = payload && payload.workflow_run && payload.workflow_run.event;
+  const is_push = workflow_run_event === 'push';
+  console.log(`event: ${workflow_run_event}, is_push: ${is_push}`);
+  const should_ignore_on_push =
+    ignore_branches_on_push && ignore_branches_on_push.indexOf(branch) >= 0;
+  console.log(`should_ignore_on_push: ${should_ignore_on_push}`);
+  if (should_ignore_on_push) {
+    console.log(`Ignore cancellation on push for branch: ${branch}`);
+    return;
+  }
   const workflow_ids: string[] = [];
   const octokit = github.getOctokit(token);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,7 @@ async function main() {
   const is_push = workflow_run_event === 'push';
   console.log(`event: ${workflow_run_event}, is_push: ${is_push}`);
   const should_ignore_on_push =
-    ignore_branches_on_push && ignore_branches_on_push.indexOf(branch) >= 0;
-  console.log(`should_ignore_on_push: ${should_ignore_on_push}`);
+    is_push && ignore_branches_on_push && ignore_branches_on_push.indexOf(branch) >= 0;
   if (should_ignore_on_push) {
     console.log(`Ignore cancellation on push for branch: ${branch}`);
     return;


### PR DESCRIPTION
Sometimes ppl may only want to cancel workflow runs that are triggered by pull requests, but not by the default branch so that every commit to the default branch can be verified by full CI and receive a green checkmark.

This PR implements the` ignore_branches_on_push` option, the branches listed will be ignored by this action on push.

Please let me know your concern or feedback, thanks!