### PR TITLE
Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Hi.  Please update this action to use Node 16.

See:  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Thanks.