### PR TITLE
Add option `only_status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,4 +192,5 @@ _Note_ : This is typical when global access is set to be restrictive. Only this 
 - Run `yarn install`
 - Edit `./src/index.ts`
 - Run `yarn build`
+- Run `yarn format`
 - Commit changes including `./dist/index.js` bundle

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ jobs:
 
 ### Advanced: Skip runs that are in progress
 
-For some workflows it might be dangerous to be canceled if they are in progress. If you want to play safe and cancel only workflows that are paused (in_queue), most likely waiting for approval to be deployed in a protected environment use `cancel_only_queued` 
+For some workflows it might be dangerous to be canceled if they are in progress. If you want to play safe and cancel only workflows that are in state `waiting`, most likely waiting for approval to be deployed in a protected environment, use `cancel_only_queued`. 
 
 ```yml
 name: Cancel

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ jobs:
 
 ### Advanced: Skip runs that are in progress
 
-For some workflows it might be dangerous to be canceled if they are in progress. If you want to play safe and cancel only workflows that are in state `waiting`, most likely waiting for approval to be deployed in a protected environment, use `cancel_only_queued`. 
+Some workflows may be dangerous to cancel when they are in progress. If you want to play safe and cancel only workflows that are in state `waiting`, most likely waiting for approval to be deployed in a protected environment, use `only_status` to only cancel runs with a specific status. 
 
 ```yml
 name: Cancel
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action
         with:
-          cancel_only_queued: true
+          only_status: 'waiting'
 ```
 
 ### Advanced: Token Permissions

--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ jobs:
           all_but_latest: true
 ```
 
+### Advanced: Skip runs that are in progress
+
+For some workflows it might be dangerous to be canceled if they are in progress. If you want to play safe and cancel only workflows that are paused (in_queue), most likely waiting for approval to be deployed in a protected environment use `cancel_only_queued` 
+
+```yml
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action
+        with:
+          cancel_only_queued: true
+```
+
 ### Advanced: Token Permissions
 
 No change to permissions is required by default. The instructions below are for improved control over of those permissions.

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,12 @@ inputs:
     default: ${{ github.token }}
     required: false
   all_but_latest:
-    description: "Cancel all actions but the last one"
+    description: "Optional - Cancel all actions but the most recent one."
     required: false
     default: 'false'
-  cancel_only_queued:
-    description: "Cancel only `waiting` runs (waiting for approval), skip the ones that are `in_progress` (safer)"
+  only_status:
+    description: "Optional - Cancel runs with a specific status, such as `waiting`."
     required: false
-    default: 'false'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: 'false'
   cancel_only_queued:
-    description: "Cancel only 'queued' runs (with steps waiting for approval), skip the ones that are in progress (safer)"
+    description: "Cancel only `waiting` runs (waiting for approval), skip the ones that are `in_progress` (safer)"
     required: false
     default: 'false'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "Cancel all actions but the last one"
     required: false
     default: 'false'
+  cancel_only_queued:
+    description: "Cancel only 'queued' runs (with steps waiting for approval), skip the ones that are in progress (safer)"
+    required: false
+    default: 'false'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9706,6 +9706,7 @@ async function main() {
     const workflow_id = core.getInput('workflow_id', { required: false });
     const ignore_sha = core.getBooleanInput('ignore_sha', { required: false });
     const all_but_latest = core.getBooleanInput('all_but_latest', { required: false });
+    const cancel_only_queued = core.getBooleanInput('cancel_only_queued', { required: false });
     console.log(`Found token: ${token ? 'yes' : 'no'}`);
     const workflow_ids = [];
     const octokit = github.getOctokit(token);
@@ -9753,6 +9754,9 @@ async function main() {
                 (ignore_sha || run.head_sha !== headSha) &&
                 run.status !== 'completed' &&
                 new Date(run.created_at) < cancelBefore);
+            if (cancel_only_queued) {
+                runningWorkflows.filter(run => run.status === 'queued');
+            }
             if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
                 runningWorkflows.push(current_run);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9706,7 +9706,7 @@ async function main() {
     const workflow_id = core.getInput('workflow_id', { required: false });
     const ignore_sha = core.getBooleanInput('ignore_sha', { required: false });
     const all_but_latest = core.getBooleanInput('all_but_latest', { required: false });
-    const cancel_only_queued = core.getBooleanInput('cancel_only_queued', { required: false });
+    const only_status = core.getInput('only_status', { required: false });
     console.log(`Found token: ${token ? 'yes' : 'no'}`);
     const workflow_ids = [];
     const octokit = github.getOctokit(token);
@@ -9752,9 +9752,8 @@ async function main() {
             const runningWorkflows = workflow_runs.filter(run => run.head_repository.id === trigger_repo_id &&
                 run.id !== current_run.id &&
                 (ignore_sha || run.head_sha !== headSha) &&
-                cancel_only_queued
-                ? run.status === 'waiting'
-                : run.status !== 'completed' && new Date(run.created_at) < cancelBefore);
+                (only_status ? run.status === only_status : run.status !== 'completed') &&
+                new Date(run.created_at) < cancelBefore);
             if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
                 runningWorkflows.push(current_run);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9752,11 +9752,8 @@ async function main() {
             const runningWorkflows = workflow_runs.filter(run => run.head_repository.id === trigger_repo_id &&
                 run.id !== current_run.id &&
                 (ignore_sha || run.head_sha !== headSha) &&
-                run.status !== 'completed' &&
+                cancel_only_queued ? run.status ===  'waiting' : run.status !== 'completed' &&
                 new Date(run.created_at) < cancelBefore);
-            if (cancel_only_queued) {
-                runningWorkflows.filter(run => run.status === 'waiting');
-            }
             if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
                 runningWorkflows.push(current_run);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9755,7 +9755,7 @@ async function main() {
                 run.status !== 'completed' &&
                 new Date(run.created_at) < cancelBefore);
             if (cancel_only_queued) {
-                runningWorkflows.filter(run => run.status === 'queued');
+                runningWorkflows.filter(run => run.status === 'waiting');
             }
             if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
                 runningWorkflows.push(current_run);

--- a/dist/index.js
+++ b/dist/index.js
@@ -9762,7 +9762,7 @@ async function main() {
             }
             console.log(`Found ${runningWorkflows.length} runs to cancel.`);
             for (const { id, head_sha, status, html_url } of runningWorkflows) {
-                console.log('Canceling run: ', { id, head_sha, status, html_url });
+                console.log('Canceling run 2: ', { id, head_sha, status, html_url });
                 const res = await octokit.rest.actions.cancelWorkflowRun({
                     owner,
                     repo,

--- a/dist/index.js
+++ b/dist/index.js
@@ -9752,14 +9752,15 @@ async function main() {
             const runningWorkflows = workflow_runs.filter(run => run.head_repository.id === trigger_repo_id &&
                 run.id !== current_run.id &&
                 (ignore_sha || run.head_sha !== headSha) &&
-                cancel_only_queued ? run.status ===  'waiting' : run.status !== 'completed' &&
-                new Date(run.created_at) < cancelBefore);
+                cancel_only_queued
+                ? run.status === 'waiting'
+                : run.status !== 'completed' && new Date(run.created_at) < cancelBefore);
             if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
                 runningWorkflows.push(current_run);
             }
             console.log(`Found ${runningWorkflows.length} runs to cancel.`);
             for (const { id, head_sha, status, html_url } of runningWorkflows) {
-                console.log('Canceling run 2: ', { id, head_sha, status, html_url });
+                console.log('Canceling run: ', { id, head_sha, status, html_url });
                 const res = await octokit.rest.actions.cancelWorkflowRun({
                     owner,
                     repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,10 +94,9 @@ async function main() {
             run.status !== 'completed' &&
             new Date(run.created_at) < cancelBefore,
         );
-        if(cancel_only_queued) {
-          runningWorkflows.filter(run =>
-            run.status === 'queued');
-        };
+        if (cancel_only_queued) {
+          runningWorkflows.filter(run => run.status === 'queued');
+        }
         if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
           // Make sure we cancel this run itself if it's out-of-date.
           // We must cancel this run last so we can cancel the others first.

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,17 +86,14 @@ async function main() {
             .reduce((a, b) => Math.max(a, b), cancelBefore.getTime());
           cancelBefore = new Date(n);
         }
-        const runningWorkflows = workflow_runs.filter(
-          run =>
-            run.head_repository.id === trigger_repo_id &&
-            run.id !== current_run.id &&
-            (ignore_sha || run.head_sha !== headSha) &&
-            run.status !== 'completed' &&
-            new Date(run.created_at) < cancelBefore,
+        const runningWorkflows = workflow_runs.filter(run =>
+          run.head_repository.id === trigger_repo_id &&
+          run.id !== current_run.id &&
+          (ignore_sha || run.head_sha !== headSha) &&
+          cancel_only_queued
+            ? run.status === 'waiting'
+            : run.status !== 'completed' && new Date(run.created_at) < cancelBefore,
         );
-        if (cancel_only_queued) {
-          runningWorkflows.filter(run => run.status === 'queued');
-        }
         if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
           // Make sure we cancel this run itself if it's out-of-date.
           // We must cancel this run last so we can cancel the others first.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ async function main() {
   const workflow_id = core.getInput('workflow_id', { required: false });
   const ignore_sha = core.getBooleanInput('ignore_sha', { required: false });
   const all_but_latest = core.getBooleanInput('all_but_latest', { required: false });
+  const cancel_only_queued = core.getBooleanInput('cancel_only_queued', { required: false });
   console.log(`Found token: ${token ? 'yes' : 'no'}`);
   const workflow_ids: string[] = [];
   const octokit = github.getOctokit(token);
@@ -93,6 +94,10 @@ async function main() {
             run.status !== 'completed' &&
             new Date(run.created_at) < cancelBefore,
         );
+        if(cancel_only_queued) {
+          runningWorkflows.filter(run =>
+            run.status === 'queued');
+        };
         if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
           // Make sure we cancel this run itself if it's out-of-date.
           // We must cancel this run last so we can cancel the others first.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ async function main() {
   const workflow_id = core.getInput('workflow_id', { required: false });
   const ignore_sha = core.getBooleanInput('ignore_sha', { required: false });
   const all_but_latest = core.getBooleanInput('all_but_latest', { required: false });
-  const cancel_only_queued = core.getBooleanInput('cancel_only_queued', { required: false });
+  const only_status = core.getInput('only_status', { required: false });
   console.log(`Found token: ${token ? 'yes' : 'no'}`);
   const workflow_ids: string[] = [];
   const octokit = github.getOctokit(token);
@@ -86,13 +86,13 @@ async function main() {
             .reduce((a, b) => Math.max(a, b), cancelBefore.getTime());
           cancelBefore = new Date(n);
         }
-        const runningWorkflows = workflow_runs.filter(run =>
-          run.head_repository.id === trigger_repo_id &&
-          run.id !== current_run.id &&
-          (ignore_sha || run.head_sha !== headSha) &&
-          cancel_only_queued
-            ? run.status === 'waiting'
-            : run.status !== 'completed' && new Date(run.created_at) < cancelBefore,
+        const runningWorkflows = workflow_runs.filter(
+          run =>
+            run.head_repository.id === trigger_repo_id &&
+            run.id !== current_run.id &&
+            (ignore_sha || run.head_sha !== headSha) &&
+            (only_status ? run.status === only_status : run.status !== 'completed') &&
+            new Date(run.created_at) < cancelBefore,
         );
         if (all_but_latest && new Date(current_run.created_at) < cancelBefore) {
           // Make sure we cancel this run itself if it's out-of-date.


### PR DESCRIPTION
Developers sometimes leave the workflows in queued state. This happens when you have a protected environment and deployment is waiting for approval. They sometimes do not approve and just leave the workflow pending waiting for a merge that will start a new workflow run and deploy from there multiple merges at once.

We need to cancel the older pending ones if new PR is merged but SKIP canceling workflows that are running as it might be dangerous to interrupt it. To play it safe we introduce `only_status: 'waiting'` in order to avoid canceling runs with status `in_progress`

GitHub official implementation also does not support this option and they do not have plans to implement it soon, so we are adding it to this action
