### PR TITLE
fix: paginate workflow run cancellation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30283,14 +30283,18 @@ async function main() {
     const trigger_repo_id = (payload.workflow_run || current_run).head_repository.id;
     await Promise.all(workflow_ids.map(async (workflow_id) => {
         try {
-            const { data: { total_count, workflow_runs }, } = await octokit.rest.actions.listWorkflowRuns({
+            const listWorkflowRunsParams = {
                 per_page: 100,
                 owner,
                 repo,
                 workflow_id,
                 branch,
-            });
-            console.log(`Found ${total_count} runs total.`);
+            };
+            if (only_status && !all_but_latest) {
+                listWorkflowRunsParams.status = only_status;
+            }
+            const workflow_runs = await octokit.paginate(octokit.rest.actions.listWorkflowRuns, listWorkflowRunsParams);
+            console.log(`Found ${workflow_runs.length} runs total.`);
             let cancelBefore = new Date(current_run.created_at);
             if (all_but_latest) {
                 const n = workflow_runs

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,17 +69,21 @@ async function main() {
   await Promise.all(
     workflow_ids.map(async workflow_id => {
       try {
-        const {
-          data: { total_count, workflow_runs },
-        } = await octokit.rest.actions.listWorkflowRuns({
+        const listWorkflowRunsParams: any = {
           per_page: 100,
           owner,
           repo,
-          // @ts-ignore
           workflow_id,
           branch,
-        });
-        console.log(`Found ${total_count} runs total.`);
+        };
+        if (only_status && !all_but_latest) {
+          listWorkflowRunsParams.status = only_status;
+        }
+        const workflow_runs: any[] = await octokit.paginate(
+          octokit.rest.actions.listWorkflowRuns,
+          listWorkflowRunsParams,
+        );
+        console.log(`Found ${workflow_runs.length} runs total.`);
         let cancelBefore = new Date(current_run.created_at);
         if (all_but_latest) {
           const n = workflow_runs


### PR DESCRIPTION
## Summary

- paginate `listWorkflowRuns` so the action considers every matching workflow run, not just the first 100 returned by the API
- when `only_status` is set and `all_but_latest` is not set, pass that status to the API so runs in statuses like `waiting` are not hidden behind recent completed runs
- keep `all_but_latest` semantics by fetching all statuses when that option is enabled

Fixes #218.

## Test Plan

- `yarn format-check`
- `yarn build`
- `npx tsc --noEmit`
